### PR TITLE
Validate response packet to make sure it's the one we're expecting

### DIFF
--- a/src/PowerPing/Display.cs
+++ b/src/PowerPing/Display.cs
@@ -598,7 +598,8 @@ Get location information for 84.23.12.4";
 
             // Display ICMP message (if specified)
             if (ShowMessages) {
-                Console.Write(REPLY_MSG_TXT, new string(Encoding.ASCII.GetString(packet.message).Where(c => !char.IsControl(c)).ToArray()));
+                string messageWithoutHeader = Encoding.ASCII.GetString(packet.message, 4, packet.message.Length - 4);
+                Console.Write(REPLY_MSG_TXT, new string(messageWithoutHeader.Where(c => !char.IsControl(c)).ToArray()));
             }
 
             // Print coloured time segment

--- a/src/PowerPing/Helper.cs
+++ b/src/PowerPing/Helper.cs
@@ -35,6 +35,8 @@ namespace PowerPing
     /// </summary>
     public static class Helper
     {
+        private static readonly double stopwatchToTimeSpanTicksScale = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
+
         /// <summary>
         /// Pause program and wait for user input
         /// </summary>
@@ -154,10 +156,15 @@ namespace PowerPing
             return localTime;
         }
 
+        public static ushort GenerateSessionId()
+        {
+            uint n = (uint)Process.GetCurrentProcess().Id;
+            return (ushort)(n ^ (n >> 16));
+        }
+
         public static long StopwatchToTimeSpanTicks(long stopwatchTicks)
         {
-            double scale = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
-            return (long)(stopwatchTicks * scale);
+            return (long)(stopwatchTicks * stopwatchToTimeSpanTicksScale);
         }
     }
 }

--- a/src/PowerPing/Helper.cs
+++ b/src/PowerPing/Helper.cs
@@ -23,6 +23,7 @@ SOFTWARE.
 */
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -153,5 +154,10 @@ namespace PowerPing
             return localTime;
         }
 
+        public static long StopwatchToTimeSpanTicks(long stopwatchTicks)
+        {
+            double scale = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
+            return (long)(stopwatchTicks * scale);
+        }
     }
 }

--- a/src/PowerPing/Ping.cs
+++ b/src/PowerPing/Ping.cs
@@ -46,7 +46,7 @@ namespace PowerPing
         public PingAttributes Attributes { get; private set; } = new PingAttributes(); // Stores the current operation's attributes
         public bool IsRunning { get; private set; } = false;
 
-        private static readonly ushort sessionId = GenerateSessionId();
+        private static readonly ushort sessionId = Helper.GenerateSessionId();
         private readonly ManualResetEvent cancelEvent = new ManualResetEvent(false);
         private bool debug = false;
 
@@ -382,9 +382,6 @@ namespace PowerPing
                 if (attrs.RandomMsg) {
                     payload = Encoding.ASCII.GetBytes(Helper.RandomString());
                     Buffer.BlockCopy(payload, 0, packet.message, 4, payload.Length);
-                } else if (attrs.UsePingCookies) {
-                    payload = Encoding.ASCII.GetBytes(DateTime.Now.ToString("HHmmssff") + "#" + index); //fffff
-                    Buffer.BlockCopy(payload, 0, packet.message, 4, payload.Length);
                 }
 
                 // Update packet checksum
@@ -508,12 +505,6 @@ namespace PowerPing
             sock.Close();
 
             return Results;
-        }
-
-        private static ushort GenerateSessionId()
-        {
-            uint n = (uint)Process.GetCurrentProcess().Id;
-            return (ushort)(n ^ (n >> 16));
         }
 
         #region IDisposable Support

--- a/src/PowerPing/PingAttributes.cs
+++ b/src/PowerPing/PingAttributes.cs
@@ -48,7 +48,6 @@ namespace PowerPing
         public bool ForceV4 { get; set; } // Force use of IPv4
         public bool ForceV6 { get; set; } // Force use of IPv6 
         public bool RandomMsg { get; set; } // Fills ICMP message field with random characters    
-        public bool UsePingCookies { get; set; } // Stores timestamp and seq num in ICMP data for more accurate readings
         public bool DontFragment { get; set; } // Sets the Don't Fragment flag in an IPv4 header
         public bool RandomTiming { get; set; } // Generate random wait time each time ping is sent
         public string[] AddressList { get; set; } // Optional attribute: Used when scanning, stores addresses to ping
@@ -70,7 +69,6 @@ namespace PowerPing
             ForceV4 = true;
             ForceV6 = false;
             RandomMsg = false;
-            UsePingCookies = false;
 	        BeepLevel = 0;
             AddressList = null;
             RecieveBufferSize = 5096;

--- a/src/PowerPing/Program.cs
+++ b/src/PowerPing/Program.cs
@@ -380,14 +380,6 @@ namespace PowerPing
                             case "--ia":
                                 Display.UseInputtedAddress = true;
                                 break;
-                            case "/cookies":
-                            case "-cookies":
-                            case "--cookies":
-                            case "/co":
-                            case "-co":
-                            case "--co":
-                                attributes.UsePingCookies = true;
-                                break;
                             case "/buffer":
                             case "-buffer":
                             case "--buffer":


### PR DESCRIPTION
Attempted fix for #57. I noticed RFC 792 purposes the 4 bytes after an echo message's checksum for an identifier + sequence number, so I used that pattern.

I also fixed an issue where the displayed message had extra characters at the beginning sometimes.

Feel free to close this if you have a better idea or don't like my coding style or whatever 😄 - I just wanted to offer this as an idea.