### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
https://editorconfig.org/

This file tells Visual Studio and other IDEs to use spaces for indentation, even if it is normally configured to use tabs (like mine is). Makes it easier for other contributors to adhere to your coding preferences!