### PR TITLE
Cisco IOS style symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ _Future features:_
         --timestamp     [--ts]           Display timestamps (add 'UTC' for Coordinated Universal Time)
         --fulltimestamp [--fts]          Display full timestamps with localised date and time
         --nocolor       [--nc]           No colour
-        --symbols       [--sym]          Renders replies and timeouts as ASCII symbols (add '1' for alt theme)
+        --symbols       [--sym]          Renders replies and timeouts as ASCII symbols (add '1' for alt theme, add '2' for Cisco IOS style)
         --requests      [--r]            Show request packets
         --notimeouts    [--nt]           Don't display timeout messages
         --quiet         [--q]            No output (only affects normal ping)

--- a/src/Display/ConsoleDisplay.cs
+++ b/src/Display/ConsoleDisplay.cs
@@ -117,6 +117,14 @@ namespace PowerPing
                 _replySymbols.ExtremeResponseTime = ProgramStrings.REPLY_GT_500_MS_SYMBOL_1;
                 _replySymbols.Timeout = ProgramStrings.REPLY_TIMEOUT_SYMBOL_1;
             }
+            else if (theme == 2)
+            {
+                _replySymbols.LowResponseTime = ProgramStrings.REPLY_LT_100_MS_SYMBOL_3;
+                _replySymbols.MidResponseTime = ProgramStrings.REPLY_LT_250_MS_SYMBOL_3;
+                _replySymbols.HighResponseTime = ProgramStrings.REPLY_LT_500_MS_SYMBOL_3;
+                _replySymbols.ExtremeResponseTime = ProgramStrings.REPLY_GT_500_MS_SYMBOL_3;
+                _replySymbols.Timeout = ProgramStrings.REPLY_TIMEOUT_SYMBOL_3;
+            }
             else
             {
                 _replySymbols.LowResponseTime = ProgramStrings.REPLY_LT_100_MS_SYMBOL_2;

--- a/src/Display/Strings.cs
+++ b/src/Display/Strings.cs
@@ -84,6 +84,13 @@ Well done brave soul, I don't know your motive but I salute you =^-^=";
         public const string REPLY_GT_500_MS_SYMBOL_2 = "█";
         public const string REPLY_TIMEOUT_SYMBOL_2 = "!";
 
+        // Cisco IOS style
+        public const string REPLY_LT_100_MS_SYMBOL_3 = "!";
+        public const string REPLY_LT_250_MS_SYMBOL_3 = "!";
+        public const string REPLY_LT_500_MS_SYMBOL_3 = "!";
+        public const string REPLY_GT_500_MS_SYMBOL_3 = "!";
+        public const string REPLY_TIMEOUT_SYMBOL_3 = ".";
+
         public const string HELP_MSG =
 @"__________                         __________.__                
 \______   \______  _  __ __________\______   \__| ____    ____  
@@ -123,7 +130,7 @@ Display Arguments:
     --timestamp     [--ts]           Display timestamps (add 'UTC' for Coordinated Universal Time)
     --fulltimestamp [--fts]          Display full timestamps with localised date and time
     --nocolor       [--nc]           No colour
-    --symbols       [--sym]          Renders replies and timeouts as ASCII symbols (add '1' for alt theme)
+    --symbols       [--sym]          Renders replies and timeouts as ASCII symbols (add '1' for alt theme, add '2' for Cisco IOS style)
     --requests      [--r]            Show request packets
     --notimeouts    [--nt]           Don't display timeout messages
     --quiet         [--q]            No output (only affects normal ping)


### PR DESCRIPTION
Use characters from Cisco IOS routers to represent success (!) and timeout (.) in ping replies.